### PR TITLE
fix: Add early exit for token deletion

### DIFF
--- a/src/scripts/mountManager.js
+++ b/src/scripts/mountManager.js
@@ -143,7 +143,11 @@ export class MountManager {
      */
     static async handleTokenDelete(tokenId) {
         let token = findTokenById(tokenId);
-
+        
+        if (!token) {
+            return true;
+        }
+        
         if (this.isaRider(token.id)) {
             let mount = findTokenById(token.getFlag(FlagScope, Flags.Mount));
             await mount.unsetFlag(FlagScope, Flags.Riders);


### PR DESCRIPTION
If for some reason the `findTokenById` fails to find a token, then both the `isaRider` and `isaMount` will throw errors. This is a small change which should merely exit early when this happens.